### PR TITLE
fix: terminal size failover

### DIFF
--- a/jiratime/__init__.py
+++ b/jiratime/__init__.py
@@ -237,7 +237,11 @@ to execute a full weekly schedule for this / last week.
                 "actually been submitted. Re-run with the -y flag to submit time.\n"
             )
         for day in date_list:
-            progress.print("-" * os.get_terminal_size().columns)
+            try:
+                term_size_columns = os.get_terminal_size().columns
+            except OSError:
+                term_size_columns = 80
+            progress.print("-" * term_size_columns)
             iso_date = day.isoformat()
             day_progress = progress.add_task(
                 f"[green]Logging work for {iso_date}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "jiratime"
-version = "0.1.0"
+version = "0.1.1"
 description = "Submits time for worked hours in CTS Appsbroker Jira."
 authors = ["Svetlin Zamfirov <svetlin.zamfirov@cts.co>"]
 readme = "README.md"


### PR DESCRIPTION
Fixing an issue with fetching the terminal size. It prevents the script from running in case you're running from e.g. a cron job.

(I guess I didn't think carefully enough about the interactive vs non-interactive part)