### PR TITLE
feat!: rename env var to prevent confusion with other API_TOKEN values

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,25 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args:
           - --baseline
           - .secrets.baseline
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.16.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+---

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ submission in JIRA.
 2.  Set the API key as an environment variable:
 
     ```sh
-    export API_TOKEN=<insert JIRA token>
+    export JIRA_API_TOKEN=<insert JIRA token>
     ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
 # `jiratime` README
 
 Just a simple script to give you a head start at automating your timesheet

--- a/jiratime/__init__.py
+++ b/jiratime/__init__.py
@@ -15,7 +15,7 @@ logging.basicConfig(level="INFO")
 log = logging.getLogger("log_work")
 
 ATLASSIAN_URL = "https://appsbroker.atlassian.net"
-API_TOKEN = os.getenv("API_TOKEN")
+JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN")
 
 # Helpers
 REQUEST_HEADERS = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -44,7 +44,7 @@ def get_user_account_id(email: str) -> str:
         url,
         headers=REQUEST_HEADERS,
         params={"query": email},
-        auth=(email, API_TOKEN),
+        auth=(email, JIRA_API_TOKEN),
         timeout=REQUEST_TIMEOUT,
     )
     result = handle_errors(resp, f"Failed to get account ID for your user")
@@ -63,7 +63,7 @@ def search_for_ticket(ticket_summary: str, email: str):
         url,
         headers=REQUEST_HEADERS,
         params=params,
-        auth=(email, API_TOKEN),
+        auth=(email, JIRA_API_TOKEN),
         timeout=REQUEST_TIMEOUT,
     )
     result = handle_errors(
@@ -86,7 +86,7 @@ def is_work_already_logged(ticket_id: str, iso_date: date, email: str) -> bool:
     resp = requests.get(
         worklog_url,
         headers=REQUEST_HEADERS,
-        auth=(email, API_TOKEN),
+        auth=(email, JIRA_API_TOKEN),
         timeout=REQUEST_TIMEOUT,
     )
     result = handle_errors(resp, f"Failed to get worklogs from {ticket_id}")
@@ -156,7 +156,7 @@ def log_work(
             worklog_url,
             headers=REQUEST_HEADERS,
             data=json.dumps(payload),
-            auth=(email, API_TOKEN),
+            auth=(email, JIRA_API_TOKEN),
             timeout=REQUEST_TIMEOUT,
         )
         handle_errors(resp, f"Failed to log work in {ticket_id} for {iso_date}")


### PR DESCRIPTION
- API_TOKEN is a generic var name and can clash with other tools that use and require an env var
- introduce conventional commits for release-please
- introduce release-please